### PR TITLE
Handle bat/batcat symlink for apt installations

### DIFF
--- a/system-deps.sh
+++ b/system-deps.sh
@@ -162,3 +162,11 @@ install_binary_release "lazygit" "jesseduffield/lazygit" "lazygit.*Linux.*${arch
 
 curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
 curl -fsSL https://opencode.ai/install | bash
+
+# Handle bat/batcat symlink for apt installations
+if ! command -v bat &>/dev/null && command -v batcat &>/dev/null; then
+  echo "Creating bat symlink to batcat..."
+  mkdir -p "$HOME/.local/bin"
+  ln -sf /usr/bin/batcat "$HOME/.local/bin/bat"
+  echo "Created bat symlink successfully"
+fi


### PR DESCRIPTION
## Summary
• Automatically creates a `bat` symlink to `batcat` when apt package manager installs bat as batcat
• Ensures consistent `bat` command availability across different package managers without manual intervention

## Test plan
- [ ] Test in Ubuntu devcontainer where apt installs batcat
- [ ] Verify bat command works after running setup.sh
- [ ] Confirm symlink is created in ~/.local/bin/bat pointing to /usr/bin/batcat
- [ ] Test that existing bat installations are not affected

🤖 Generated with [opencode](https://opencode.ai)