### PR TITLE
Set EDITOR to nvim in all shells

### DIFF
--- a/setup/shells/setup-bash.sh
+++ b/setup/shells/setup-bash.sh
@@ -7,6 +7,7 @@ touch "$HOME/.bashrc"
 prepend_entries=(
   'export PATH="$HOME/.local/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$HOME/.local/share/fnm:$HOME/.npm-global/bin:$HOME/.cargo/bin:$HOME/go/bin:$HOME/.bun/bin:$PATH"'
   'export SHELL=$(which bash)'
+  'export EDITOR=nvim'
   '[[ -n "$SSH_CONNECTION$SSH_CLIENT$SSH_TTY$DEVPOD" ]] && export BROWSER="$HOME/browser-opener.sh"'
 )
 
@@ -105,6 +106,10 @@ fi
 
 # Create bashenv file if it doesn't exist
 touch "$bashenv_file"
+
+# Keep EDITOR aligned for non-interactive bash shells too
+sed -i '/^export[[:space:]]\+EDITOR=/d; /^EDITOR=/d' "$bashenv_file"
+echo 'export EDITOR=nvim' >>"$bashenv_file"
 
 # Add az function to BASH_ENV file
 az_function='az() { AZURE_DEVOPS_EXT_PAT=$(ado-auth-helper get-access-token) command az "$@"; }'

--- a/setup/shells/setup-fish.sh
+++ b/setup/shells/setup-fish.sh
@@ -41,6 +41,8 @@ echo 'test -f $HOME/.cargo/env.fish && source $HOME/.cargo/env.fish' >"$HOME/.co
 
 echo 'set -gx SHELL (which fish)' >"$HOME/.config/fish/conf.d/shell.fish"
 
+echo 'set -gx EDITOR nvim' >"$HOME/.config/fish/conf.d/editor.fish"
+
 echo 'set -q BASH_ENV; or set -gx BASH_ENV "$HOME/.bashenv"' >"$HOME/.config/fish/conf.d/bashenv.fish"
 
 cat >"$HOME/.config/fish/conf.d/codespaces.fish" <<'EOF'

--- a/setup/shells/setup-zsh.sh
+++ b/setup/shells/setup-zsh.sh
@@ -14,7 +14,7 @@ zshenv_entries=(
   'export SHELL=${commands[zsh]:-/bin/zsh}'
   'export TMUX_POWERLINE_BUBBLE_SEPARATORS=true'
   '[[ -n "$SSH_CONNECTION$SSH_CLIENT$SSH_TTY$DEVPOD" ]] && export BROWSER="$HOME/browser-opener.sh"'
-  'export EDITOR=code'
+  'export EDITOR=nvim'
   'export BASH_ENV="${BASH_ENV:-$HOME/.bashenv}"'
   'WORDCHARS=${WORDCHARS/\//}'
 )


### PR DESCRIPTION
## Summary
- set `EDITOR=nvim` in Bash shell setup
- switch Zsh from `EDITOR=code` to `EDITOR=nvim`
- add Fish shell `EDITOR` config and keep Bash non-interactive shells aligned