### PR TITLE
Add extended-keys-format csi-u for tmux

### DIFF
--- a/setup/terminal/setup-tmux.sh
+++ b/setup/terminal/setup-tmux.sh
@@ -31,6 +31,7 @@ fi
 cat >"$HOME/.tmux.conf" <<EOF
 set -g mouse on
 set -g extended-keys on
+set -g extended-keys-format csi-u
 set -g escape-time 10
 set -g focus-events on
 set -g bell-action any


### PR DESCRIPTION
## Summary
Add `extended-keys-format csi-u` to tmux configuration.

## Changes
- Added `set -g extended-keys-format csi-u` to `setup/terminal/setup-tmux.sh`

## Rationale
This enables UTF-8 mode for extended keys in tmux, providing better support for modern terminal key input including function keys, arrow keys, and special keys. It works alongside `extended-keys on` to ensure proper key handling in tmux sessions.