### PR TITLE
Set Copilot hook localhost shell env

### DIFF
--- a/setup/shells/setup-bash.sh
+++ b/setup/shells/setup-bash.sh
@@ -8,6 +8,7 @@ prepend_entries=(
   'export PATH="$HOME/.local/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$HOME/.local/share/fnm:$HOME/.npm-global/bin:$HOME/.cargo/bin:$HOME/go/bin:$HOME/.bun/bin:$PATH"'
   'export SHELL=$(which bash)'
   'export EDITOR=nvim'
+  'export COPILOT_HOOK_ALLOW_LOCALHOST=1'
   '[[ -n "$SSH_CONNECTION$SSH_CLIENT$SSH_TTY$DEVPOD" ]] && export BROWSER="$HOME/browser-opener.sh"'
 )
 
@@ -110,6 +111,10 @@ touch "$bashenv_file"
 # Keep EDITOR aligned for non-interactive bash shells too
 sed -i '/^export[[:space:]]\+EDITOR=/d; /^EDITOR=/d' "$bashenv_file"
 echo 'export EDITOR=nvim' >>"$bashenv_file"
+
+# Keep Copilot hook localhost access aligned for non-interactive bash shells too
+sed -i '/^export[[:space:]]\+COPILOT_HOOK_ALLOW_LOCALHOST=/d; /^COPILOT_HOOK_ALLOW_LOCALHOST=/d' "$bashenv_file"
+echo 'export COPILOT_HOOK_ALLOW_LOCALHOST=1' >>"$bashenv_file"
 
 # Add az function to BASH_ENV file
 az_function='az() { AZURE_DEVOPS_EXT_PAT=$(ado-auth-helper get-access-token) command az "$@"; }'

--- a/setup/shells/setup-fish.sh
+++ b/setup/shells/setup-fish.sh
@@ -43,7 +43,6 @@ echo 'set -gx SHELL (which fish)' >"$HOME/.config/fish/conf.d/shell.fish"
 
 echo 'set -gx EDITOR nvim' >"$HOME/.config/fish/conf.d/editor.fish"
 
-rm -f "$HOME/.config/fish/conf.d/copilot-hook.fish"
 fish --command='set -Ux COPILOT_HOOK_ALLOW_LOCALHOST 1'
 
 echo 'set -q BASH_ENV; or set -gx BASH_ENV "$HOME/.bashenv"' >"$HOME/.config/fish/conf.d/bashenv.fish"

--- a/setup/shells/setup-fish.sh
+++ b/setup/shells/setup-fish.sh
@@ -43,6 +43,9 @@ echo 'set -gx SHELL (which fish)' >"$HOME/.config/fish/conf.d/shell.fish"
 
 echo 'set -gx EDITOR nvim' >"$HOME/.config/fish/conf.d/editor.fish"
 
+rm -f "$HOME/.config/fish/conf.d/copilot-hook.fish"
+fish --command='set -Ux COPILOT_HOOK_ALLOW_LOCALHOST 1'
+
 echo 'set -q BASH_ENV; or set -gx BASH_ENV "$HOME/.bashenv"' >"$HOME/.config/fish/conf.d/bashenv.fish"
 
 cat >"$HOME/.config/fish/conf.d/codespaces.fish" <<'EOF'

--- a/setup/shells/setup-zsh.sh
+++ b/setup/shells/setup-zsh.sh
@@ -15,6 +15,7 @@ zshenv_entries=(
   'export TMUX_POWERLINE_BUBBLE_SEPARATORS=true'
   '[[ -n "$SSH_CONNECTION$SSH_CLIENT$SSH_TTY$DEVPOD" ]] && export BROWSER="$HOME/browser-opener.sh"'
   'export EDITOR=nvim'
+  'export COPILOT_HOOK_ALLOW_LOCALHOST=1'
   'export BASH_ENV="${BASH_ENV:-$HOME/.bashenv}"'
   'WORDCHARS=${WORDCHARS/\//}'
 )


### PR DESCRIPTION
## Summary

- Export `COPILOT_HOOK_ALLOW_LOCALHOST=1` for bash, zsh, and fish setup
- Keep non-interactive bash shells aligned by adding the export to `$BASH_ENV`

## Validation

- `git diff --cached --check`
- `shellcheck` not run: not installed in this environment
