### PR TITLE
Migrate Copilot config.json to settings.json and merge with jq

### DIFF
--- a/setup/ai/setup-copilot.sh
+++ b/setup/ai/setup-copilot.sh
@@ -6,9 +6,15 @@ config_dir="$script_dir/../config/copilot"
 
 mkdir -p "$HOME/.copilot"
 
-config_file="$HOME/.copilot/config.json"
-if [[ ! -f "$config_file" ]]; then
-  cp -f "$config_dir/config.json" "$config_file"
+config_file="$HOME/.copilot/settings.json"
+dotfiles_settings="$config_dir/settings.json"
+if [[ -f "$config_file" ]]; then
+  # Merge dotfiles settings into the existing settings, letting dotfiles values win.
+  tmp_settings="$(mktemp)"
+  jq -s '.[0] * .[1]' "$config_file" "$dotfiles_settings" >"$tmp_settings"
+  mv "$tmp_settings" "$config_file"
+else
+  cp -f "$dotfiles_settings" "$config_file"
 fi
 
 cp -f "$config_dir/copilot-instructions.md" "$HOME/.copilot/copilot-instructions.md"

--- a/setup/config/copilot/config.json
+++ b/setup/config/copilot/config.json
@@ -1,6 +1,0 @@
-{
-  "experimental": true,
-  "mouse": true,
-  "bash_env": true,
-  "banner": "always"
-}

--- a/setup/config/copilot/settings.json
+++ b/setup/config/copilot/settings.json
@@ -1,0 +1,48 @@
+{
+  "banner": "always",
+  "experimental": true,
+  "mouse": true,
+  "bashEnv": true,
+  "allowedUrls": [
+    "http://localhost:1234",
+    "https://api.github.com",
+    "https://agentskills.io",
+    "https://docs.github.com",
+    "https://learn.microsoft.com",
+    "http://127.0.0.1:14892",
+    "http://127.0.0.1:43877"
+  ],
+  "theme": "auto",
+  "alt_screen": true,
+  "effortLevel": "high",
+  "contextTier": "long_context",
+  "colorMode": "default",
+  "subagents": {
+    "agents": {
+      "explore": {
+        "model": "gpt-5.4-mini",
+        "effortLevel": "medium"
+      },
+      "task": {
+        "model": "gpt-5.4-mini",
+        "effortLevel": "high"
+      },
+      "general-purpose": {
+        "model": "gpt-5.5",
+        "effortLevel": "high",
+        "contextTier": "long_context"
+      },
+      "code-review": {
+        "model": "complementary"
+      },
+      "research": {
+        "model": "gpt-5.5",
+        "effortLevel": "high",
+        "contextTier": "long_context"
+      },
+      "security-review": {
+        "model": "complementary"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Rename the repo-owned Copilot config from `config.json` to `settings.json` (with expanded settings: `allowedUrls`, `subagents`, theme, effort, etc.).
- Update `setup/ai/setup-copilot.sh` so that when `~/.copilot/settings.json` already exists, the dotfiles settings are deep-merged into it with `jq -s '.[0] * .[1]'` (dotfiles values win on conflicts) via a temp file, instead of being skipped. Falls back to `cp -f` when no settings file exists.

## Testing

Not run locally — per repo convention, setup scripts are only validated inside a devcontainer.