### PR TITLE
Migrate ADO plugin to agentic skills and remove Claude Code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 Cloud Dots is a dotfiles repo for GitHub Codespaces and VS Code Devcontainers. The entry point is `setup.sh`, which orchestrates all other scripts in a fixed order:
 
-1. `setup/core/system-deps.sh` — apt/dnf packages, Claude Code CLI, Bun
+1. `setup/core/system-deps.sh` — apt/dnf packages, Bun
 2. `setup/core/homebrew.sh` — Homebrew + CLI tools
 3. fnm + Node.js (inline in setup.sh)
 4. `setup/core/npm-tools.sh` — global npm packages
@@ -44,7 +44,7 @@ Set `STRICT_MODE=true` or `CI=true` to enable `set -e` in the top-level orchestr
 - `setup/shells/` — Shell configs (bash, zsh, fish)
 - `setup/editors/` — Editor setup (Neovim, Helix, VS Code)
 - `setup/terminal/` — Terminal tools (tmux, git, bat)
-- `setup/ai/` — AI tooling (Claude, Copilot)
+- `setup/ai/` — AI tooling (Copilot)
 - `setup/shims/` — Command wrapper scripts symlinked to `~/.local/bin/`
 - `setup/setup-*.sh` — Category runners that auto-discover scripts in subdirectories
 - `.devcontainer/` — Devcontainer definitions for testing
@@ -63,4 +63,5 @@ Set `STRICT_MODE=true` or `CI=true` to enable `set -e` in the top-level orchestr
 - **Strict mode is opt-in**: Individual scripts use `set -e`, but setup.sh only enables it when `STRICT_MODE=true` or `CI=true`. Category runners propagate the flag by checking `[[ $- == *e* ]]`.
 - **Never let Homebrew install `node`**: Codespaces ships its own global node install, and `brew remove node` fails when a brew formula depends on it. Do NOT add Homebrew formulae that depend on `node` (e.g. `prettier`, `yaml-language-server`, `markdownlint-cli2`) to `homebrew.sh` — install node-based tools via `npm install -g` in `setup/core/npm-tools.sh` instead. Before adding any formula to `homebrew.sh`, verify it doesn't pull in node (check `dependencies` at `formulae.brew.sh/api/formula/<name>.json`, or `brew deps <name>`).
 - **LazyVim toolchains are pre-installed, not Mason-managed**: Our Neovim config (`scaryrawr/lazyvim`, cloned by `setup/editors/setup-neovim.sh`) enables many language extras that normally rely on Mason to fetch LSP servers/toolchains on demand. Mason fails on some Codespaces, so the corresponding toolchains and servers are pre-installed via `setup/core/homebrew.sh` (or npm-tools.sh / uv). When enabling a new language extra in the lazyvim config, add its toolchain + LSP server to `homebrew.sh` so it works out-of-the-box — unless the server is node-based, in which case add it to `npm-tools.sh` (see the node rule above).
+- **AI capabilities: plugins vs. skills (two distinct sources)**: `setup/ai/setup-copilot.sh` installs agent-specific *plugins* from `scaryrawr/scarypilot`. `setup/ai/setup-skills.sh` installs cross-agent *skills* from `scaryrawr/agentic` via `gh skill install ... --scope user --agent <agent>` for every agent in its `AGENTS` array. Add new portable AI capabilities as agentic skills in `setup-skills.sh`, not as plugins. Azure DevOps tooling (`ado-cli`, `ado-pr`, `ado-work-items`, `ado-make-pr`, `ado-review-pr`) lives as agentic skills gated on an Azure DevOps `git remote get-url origin` (`dev.azure.com/`, `.visualstudio.com/`, `ssh.dev.azure.com:`); it is not the former `azure-devops@scarypilot` plugin.
 - **Diff tooling (hunk + delta coexist deliberately)**: hunk is git's `core.pager` and the native `git-difftool` choice (interactive review TUI). delta is kept on purpose for streaming/non-TTY consumers where hunk only echoes raw diff: git `interactive.diffFilter` (`git add -p`), lazygit's inline pager, and fish's `fzf_diff_highlighter`. Do not remove delta to "consolidate" on hunk. See `setup/terminal/setup-git.sh`, `setup/terminal/git-difftool.sh`, `setup/config/lazygit/config.yml`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Scripts are organized by function for clarity and maintainability:
 - **setup.sh**: Main orchestrator. Runs all other scripts in the correct order.
 - **setup/**: Setup scripts and helpers.
   - **setup/core/**: Bootstrap + package managers.
-    - **setup/core/system-deps.sh**: Installs system-level dependencies (apt/dnf), Claude Code CLI, and Bun.
+    - **setup/core/system-deps.sh**: Installs system-level dependencies (apt/dnf) and Bun.
     - **setup/core/homebrew.sh**: Installs Homebrew and development tools.
     - **setup/core/npm-tools.sh**: Installs global npm tools (language servers, etc).
   - **setup/shells/**: Shell-specific config.
@@ -25,7 +25,6 @@ Scripts are organized by function for clarity and maintainability:
     - **setup/terminal/setup-git.sh** (no-op unless Codespaces/DevPod): Wires [hunk](https://github.com/modem-dev/hunk) as the git pager and difftool; delta stays for `git add -p` and fzf previews.
     - **setup/terminal/setup-bat.sh**: Configures bat theme.
   - **setup/ai/**: AI tooling config.
-    - **setup/ai/setup-claude.sh**: Configures Claude Code plugins.
     - **setup/ai/setup-copilot.sh**: Configures Copilot CLI plugins.
     - **setup/ai/setup-pi.sh**: Configures the Pi agent.
   - **setup/shims/**: Command wrapper scripts symlinked to `~/.local/bin/`. Intercept commands (az, bun, bunx, npm, npx, pnpm, pnpx, yarn) to add authentication or environment setup before calling the real binary.
@@ -49,7 +48,7 @@ Scripts are organized by function for clarity and maintainability:
 
 ## What it does in Codespaces & Devcontainers
 
-- **Automatic system package management** (apt/dnf): Installs core CLI tools for cloud development (fish, zsh, file), Claude Code CLI, and Bun.
+- **Automatic system package management** (apt/dnf): Installs core CLI tools for cloud development (fish, zsh, file), and Bun.
 - **Homebrew**: Installs development tools including ast-grep, fzf, eza, zoxide, ripgrep, chafa, bat, fd, git-delta, hunk, tmux, helix, neovim, lazygit, marksman, copilot-cli, worktrunk, sl, and xclip.
 - **zsh** with [antidote](https://github.com/mattmc3/antidote) plugin manager:
   - [powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt
@@ -67,5 +66,5 @@ Scripts are organized by function for clarity and maintainability:
   - [tmux.fish](https://github.com/scaryrawr/tmux.fish)
   - [copilot.fish](https://github.com/scaryrawr/copilot.fish)
 - **npm tools**: typescript, typescript-language-server, vscode-langservers-extracted, pyright, @typescript/native-preview
-- **AI tools**: Claude Code CLI (installed via system-deps.sh), copilot-cli (via Homebrew)
+- **AI tools**: copilot-cli (via Homebrew)
 - **Shims**: Wrapper scripts for az, bun, bunx, npm, npx, pnpm, pnpx, and yarn that add authentication/environment setup before calling the real binary.

--- a/setup/ai/setup-claude.sh
+++ b/setup/ai/setup-claude.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-claude plugin marketplace add scaryrawr/scaryrawr-plugins || true
-
-claude plugin install typescript-native-lsp || true
-claude plugin install azure-devops || true

--- a/setup/ai/setup-copilot.sh
+++ b/setup/ai/setup-copilot.sh
@@ -35,12 +35,6 @@ install_plugins=(
   "digivolution@scarypilot"
 )
 
-# Only add azure-devops plugin if the repo origin is an Azure DevOps URL
-origin_url="$(git remote get-url origin 2>/dev/null || true)"
-if [[ "$origin_url" == *"dev.azure.com/"* ]] || [[ "$origin_url" == *".visualstudio.com/"* ]] || [[ "$origin_url" == *"ssh.dev.azure.com:"* ]]; then
-  install_plugins+=("azure-devops@scarypilot")
-fi
-
 for plugin in "${marketplace_plugins[@]}"; do
   copilot plugin marketplace add "$plugin" || true
 done

--- a/setup/ai/setup-skills.sh
+++ b/setup/ai/setup-skills.sh
@@ -11,8 +11,16 @@ if ! gh skill --help >/dev/null 2>&1; then
   exit 0
 fi
 
-AGENTS=(github-copilot claude-code codex pi opencode)
+AGENTS=(github-copilot codex pi opencode)
 SKILLS=(skill-creator image-gen)
+
+# Only install Azure DevOps skills if the repo origin is an Azure DevOps URL.
+# These skills replace the former scaryrawr/scarypilot azure-devops plugin.
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+if [[ "$origin_url" == *"dev.azure.com/"* ]] || [[ "$origin_url" == *".visualstudio.com/"* ]] || [[ "$origin_url" == *"ssh.dev.azure.com:"* ]]; then
+  SKILLS+=(ado-cli ado-pr ado-work-items ado-make-pr ado-review-pr)
+fi
+
 for skill in "${SKILLS[@]}"; do
   for agent in "${AGENTS[@]}"; do
     gh skill install scaryrawr/agentic "$skill" --scope user --agent "$agent" -f

--- a/setup/core/system-deps.sh
+++ b/setup/core/system-deps.sh
@@ -52,8 +52,7 @@ else
   exit 1
 fi
 
-# Install Claude Code CLI
-curl -fsSL https://claude.ai/install.sh | bash
+# Install Bun
 curl -fsSL https://bun.sh/install | bash
 
 # Make Bun available in the current shell session

--- a/setup/shells/setup-fish.sh
+++ b/setup/shells/setup-fish.sh
@@ -29,7 +29,7 @@ cp -f "$config_dir"/*.fish "$HOME/.config/fish/conf.d/"
 
 fish --command='set -Ux COPILOT_HOOK_ALLOW_LOCALHOST 1'
 
-fish --command="curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher jorgebucaran/replay.fish scaryrawr/claude-code.fish scaryrawr/copilot.fish scaryrawr/tide scaryrawr/codespace-nvm.fish scaryrawr/nvim.fish scaryrawr/artifacts-helper.fish franciscolourenco/done </dev/null"
+fish --command="curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher jorgebucaran/replay.fish scaryrawr/copilot.fish scaryrawr/tide scaryrawr/codespace-nvm.fish scaryrawr/nvim.fish scaryrawr/artifacts-helper.fish franciscolourenco/done </dev/null"
 fish --command="tide configure --auto --style=Rainbow --prompt_colors='16 colors' --show_time='24-hour format' --rainbow_prompt_separators=Round --powerline_prompt_heads=Round --powerline_prompt_tails=Fade --powerline_prompt_style='Two lines, character and frame' --prompt_connection=Disconnected --powerline_right_prompt_frame=No --prompt_spacing=Compact --icons='Many icons' --transient=Yes"
 fish --command="command -q zoxide && fisher install scaryrawr/zoxide.fish </dev/null"
 fish --command="command -q fzf && fisher install scaryrawr/fzf.fish scaryrawr/monorepo.fish </dev/null && set -Ux fzf_fd_opts --hidden --exclude .git --exclude .hg --exclude .svn && command -q delta && set -Ux fzf_diff_highlighter delta --paging=never"


### PR DESCRIPTION
## Summary

Two related changes to the AI tooling setup:

### Migrate Azure DevOps plugin → agentic skills
Replaces the `azure-devops@scarypilot` Copilot/Claude **plugin** with the equivalent **skills** from [`scaryrawr/agentic`](https://github.com/scaryrawr/agentic), installed via `setup/ai/setup-skills.sh`:

- `ado-cli`, `ado-pr`, `ado-work-items`, `ado-make-pr`, `ado-review-pr`
- Installed for all agents, gated on an Azure DevOps `git remote get-url origin` (`dev.azure.com/`, `.visualstudio.com/`, `ssh.dev.azure.com:`) — preserving the prior conditional behavior.

### Remove Claude Code completely
- Deleted `setup/ai/setup-claude.sh`
- Dropped the Claude Code CLI install from `setup/core/system-deps.sh`
- Removed the `scaryrawr/claude-code.fish` fisher plugin from `setup/shells/setup-fish.sh`
- Removed `claude-code` from the skills `AGENTS` list
- Updated `README.md` and `.github/copilot-instructions.md`

**Note:** `chat.useClaudeSkills` in `setup-vscode.sh` was intentionally kept — it is a Copilot Chat setting that enables SKILL.md-based skills (the ones installed here), not the Claude Code CLI.

The `az` shim / `ado-auth-helper` integration is intentionally retained, since the ADO skills still require Azure CLI auth.

## Validation
- `bash -n` syntax check passes on all modified scripts (`shellcheck` not available in this environment).
- Skill names verified against the current `scaryrawr/agentic` `skills/` directory.