### PR TITLE
Fix Node devcontainer feature install

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -10,7 +10,7 @@
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/devcontainers/features/node:": {
+    "ghcr.io/devcontainers/features/node:2": {
       "version": "2.1.0",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
       "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers/features/node:": {},
+		"ghcr.io/devcontainers/features/node:2": {
+			"pnpmVersion": "none"
+		},
 		"ghcr.io/devcontainers/features/sshd:1": {}
 	}
 


### PR DESCRIPTION
The Node feature was failing while running `npm install -g pnpm@latest` because the npm registry TLS connection reset. This config does not use pnpm, so disable that optional install and correct the feature identifier from `node:` to `node:2`.

The Node feature installation completes on `mcr.microsoft.com/devcontainers/base:noble` with this option.