### PR TITLE
Remove tmux cleanup from fish setup

### DIFF
--- a/setup/shells/setup-fish.sh
+++ b/setup/shells/setup-fish.sh
@@ -35,6 +35,5 @@ fish --command="tide configure --auto --style=Rainbow --prompt_colors='16 colors
 fish --command="command -q zoxide && fisher install scaryrawr/zoxide.fish </dev/null"
 fish --command="command -q fzf && fisher install scaryrawr/fzf.fish scaryrawr/monorepo.fish </dev/null && set -Ux fzf_fd_opts --hidden --exclude .git --exclude .hg --exclude .svn && command -q delta && set -Ux fzf_diff_highlighter delta --paging=never"
 fish --command="command -q eza && fisher install scaryrawr/fish-eza </dev/null"
-fish --command="if fisher list | string match -qx 'scaryrawr/tmux.fish'; fisher remove scaryrawr/tmux.fish </dev/null; end; set -eU TMUX_POWERLINE_BUBBLE_SEPARATORS; set -eU TMUX_SSHAUTO_START; true"
 fish --command="set -Ux HERDR_AUTOSTART true"
 fish --command="set -Ux EZA_STANDARD_OPTIONS --icons=auto"


### PR DESCRIPTION
## Summary

- remove the obsolete tmux Fisher uninstaller from fish setup
- stop clearing the legacy tmux universal variables during setup